### PR TITLE
鍵盤ハイライトビューの実装

### DIFF
--- a/lib/visualizer.h
+++ b/lib/visualizer.h
@@ -6,7 +6,7 @@
 // 引数: track - チャンネル番号(sq1:0, sq2:1, tri:2, noise:3, dpcm:4)
 //
 // ノート番号(音程)を取得
-extern unsigned char visualizer_get_note(unsigned char track);
+extern unsigned char visualizer_get_note_pitch_num(unsigned char track);
 
 // 音量(0-8)を取得
 extern unsigned char visualizer_get_volume(unsigned char track);

--- a/lib/visualizer.s
+++ b/lib/visualizer.s
@@ -3,8 +3,9 @@
 ; 引数 x: チャンネル番号 (Sq1=0, Sq2=1, Tri=2, Noise=3, DPCM=4)
 ;
 ; 該当チャンネルで発音されているノート番号(音程)を取得
-.export _visualizer_get_note
-.proc _visualizer_get_note
+; 戻り値: ノート番号(音程): 1-96、未発音時は0
+.export _visualizer_get_note_pitch_num
+.proc _visualizer_get_note_pitch_num
     tax
     lda famistudio_chn_note, x
     rts

--- a/src/main.c
+++ b/src/main.c
@@ -91,16 +91,50 @@ void volume_bar_update() {
     }
 }
 
+const unsigned char channel_keyboard_y[3] = {112, 144, 176};
+const unsigned char channel_sprite_id[3] = {0, 4, 8};
+const unsigned char key_tile[12] = {0xC0, 0xC8, 0xC2, 0xC8, 0xC4, 0xC6, 0xC8, 0xC2, 0xC8, 0xC2, 0xC8, 0xC4};
+const unsigned char key_size[12]  = {1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1};
+const unsigned char key_offset[12] = {0, 1, 2, 4, 5, 8, 10, 11, 13, 14, 16, 17};
+
+// 入力されたノート番号を元にスプライトを表示
+void highlight_key_sprite(unsigned char channel) {
+    unsigned char note = visualizer_get_note(channel);
+    unsigned char octave = (note - 1) / 12;
+    unsigned char key_index = (note - 1) % 12;
+
+    unsigned char sprite_x = 17 + (octave * 32) + key_index + key_offset[key_index] - 32;
+    unsigned char sprite_y = channel_keyboard_y[channel] - 1;
+
+    oam_size(1);
+
+    if (note == 0) {
+        oam_spr(sprite_x, -1, key_tile[key_index], 2&3, channel_sprite_id[channel]);
+    } else {
+        oam_spr(sprite_x, sprite_y, key_tile[key_index], 2&3, channel_sprite_id[channel]);
+    }
+}
+
+void sprite_update() {
+    int i;
+    for (i = 0; i < 3; i++) {
+        highlight_key_sprite(i);
+    }
+}
+
 // 画面表示のセットアップ関数
 void setup_graphics() {
     ppu_off(); // PPUをオフにする
 
     pal_bg((const char *)main_pal);
+    pal_spr((const char *)main_pal);
 
     vram_adr(NAMETABLE_A);
     vram_write((unsigned char *)main_nam, 1024);
 
     put_str(NTADR_A(6, 6), "Music Player for NES!"); // 画面に文字列を表示
+
+    oam_clear();
 
     ppu_on_all(); // PPUをオンにする
 }
@@ -144,5 +178,6 @@ void main() {
         check_input();
         famistudio_update();
         volume_bar_update();
+        sprite_update();
     }
 }


### PR DESCRIPTION
# 概要
各チャンネルの発音時に対応する音程のピアノ鍵盤を光らせるハイライトビューの実装

## 詳細
- 各チャンネルの音程を取得し、対応する鍵盤をスプライト表示方式で光らせる演出を実装
- 鍵盤タイルセットを8x16のスプライトとして表示
- 音量バー表示部分のコードを調整